### PR TITLE
Rule for H character should be 'Drop H if after vowel and not before a vowel'

### DIFF
--- a/jellyfish/_jellyfish.py
+++ b/jellyfish/_jellyfish.py
@@ -422,7 +422,7 @@ def metaphone(s):
             elif next == 'h' and nextnext and nextnext not in 'aeiou':
                 i += 1
         elif c == 'h':
-            if i == 0 or next in 'aeiou' or s[i-1] in 'aeiou':
+            if i == 0 or next in 'aeiou' or s[i-1] not in 'aeiou':
                 result.append('h')
         elif c == 'k':
             if i == 0 or s[i-1] != 'c':


### PR DESCRIPTION
So, I think this is the correct fix for #46. The rule from the Wikipedia metaphone entry:

`Drop 'H' if after vowel and not before a vowel.`

And from one of the original C implementations:

`SILENT if after vowel and no vowel follows`

I think what I have here is the inverse of those statements since we're keeping the H instead of dropping it. This passes tests with the updated https://github.com/jamesturk/jellyfish-testdata repo.