### PR TITLE
Unquote the bulleted lists in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,19 +31,19 @@ Included Algorithms
 
 String comparison:
 
-  * Levenshtein Distance
-  * Damerau-Levenshtein Distance
-  * Jaro Distance
-  * Jaro-Winkler Distance
-  * Match Rating Approach Comparison
-  * Hamming Distance
+* Levenshtein Distance
+* Damerau-Levenshtein Distance
+* Jaro Distance
+* Jaro-Winkler Distance
+* Match Rating Approach Comparison
+* Hamming Distance
 
 Phonetic encoding:
 
-  * American Soundex
-  * Metaphone
-  * NYSIIS (New York State Identification and Intelligence System)
-  * Match Rating Codex
+* American Soundex
+* Metaphone
+* NYSIIS (New York State Identification and Intelligence System)
+* Match Rating Codex
 
 Example Usage
 =============


### PR DESCRIPTION
Prepending each list item with spaces makes ReST think you are quoting them. You can see this both here [on GitHub](https://github.com/jamesturk/jellyfish/blob/5ce76a98e55abf7dc961879311c230e5e6e87cf6/README.rst#included-algorithms) and [on PyPI](https://pypi.python.org/pypi/jellyfish/0.5.6).

This PR fixes the formatting so the lists show up as regular lists, as I believe was intended.