### PR TITLE
Fix style errors

### DIFF
--- a/jellyfish/_jellyfish.py
+++ b/jellyfish/_jellyfish.py
@@ -7,12 +7,13 @@ from .porter import Stemmer
 def _normalize(s):
     return unicodedata.normalize('NFKD', s)
 
-def _check_type(s):
 
+def _check_type(s):
     if IS_PY3 and not isinstance(s, str):
         raise TypeError('expected str or unicode, got %s' % type(s).__name__)
     elif not IS_PY3 and not isinstance(s, unicode):
         raise TypeError('expected unicode, got %s' % type(s).__name__)
+
 
 def levenshtein_distance(s1, s2):
     _check_type(s1)
@@ -310,7 +311,7 @@ def nysiis(s):
 
 def match_rating_codex(s):
     _check_type(s)
-    
+
     s = s.upper()
     codex = []
 

--- a/jellyfish/test.py
+++ b/jellyfish/test.py
@@ -112,7 +112,6 @@ if platform.python_implementation() == 'CPython':
         # this segfaulted on 0.1.2
         assert [[jf.match_rating_comparison(h1, h2) for h1 in sha1s] for h2 in sha1s]
 
-
     def test_damerau_levenshtein_unicode_segfault():
         # unfortunate difference in behavior between Py & C versions
         from jellyfish.cjellyfish import damerau_levenshtein_distance as c_dl


### PR DESCRIPTION
It looks like the build is broken because of some style errors. This is what I get when I run tox on a fresh checkout of Jellyfish:

```
flake8 runtests: commands[0] | flake8 jellyfish
jellyfish/_jellyfish.py:10:1: E302 expected 2 blank lines, found 1
jellyfish/_jellyfish.py:17:1: E302 expected 2 blank lines, found 1
jellyfish/_jellyfish.py:313:1: W293 blank line contains whitespace
jellyfish/test.py:116:5: E303 too many blank lines (2)
ERROR: InvocationError: '.../jellyfish/.tox/flake8/bin/flake8 jellyfish'
```

This PR fixes those errors.

Not sure how these errors got by Travis and AppVeyor, but from the looks of it those build are currently broken, so perhaps they didn't.