### PR TITLE
Easy trick for users to check if they are using Python or C code

### DIFF
--- a/jellyfish/__init__.py
+++ b/jellyfish/__init__.py
@@ -1,4 +1,6 @@
 try:
     from .cjellyfish import *   # noqa
+    library = "C"
 except ImportError:
     from ._jellyfish import *   # noqa
+    library = "Python"


### PR DESCRIPTION
Maybe I'm missing the (simple) trick to do this. But what about this:

```
>>> import jellyfish
>>> print (jellyfish.library)
Python
```

or 


```
>>> import jellyfish
>>> print (jellyfish.library)
C
```