### PR TITLE
Enable full tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: python
-python: 3.5
-env:
-    - TOX_ENV=py27
-    - TOX_ENV=py33
-    - TOX_ENV=py34
-    - TOX_ENV=py35
-    - TOX_ENV=pypy
 install: pip install tox
-script: tox -e $TOX_ENV
+script: tox
 after_success:
     - coveralls
 notifications:


### PR DESCRIPTION
As we saw in #67, if a test is not instrumented as part of our CI build then it doesn't help prevent bugs and style errors from creeping into the code base.

This PR enables the full set of tests that we run locally to also run on Travis CI.