### PR TITLE
Deprecate jaro_winkler in favor of jaro_winkler_distance

### DIFF
--- a/docs/comparison.rst
+++ b/docs/comparison.rst
@@ -56,7 +56,7 @@ Jaro distance is a string-edit distance that gives a floating point response in 
 Jaro-Winkler Distance
 ---------------------
 
-.. py:function:: jaro_winkler(s1, s2)
+.. py:function:: jaro_winkler_distance(s1, s2)
 
     Compute the Jaro-Winkler distance between s1 and s2.
 

--- a/jellyfish/_jellyfish.py
+++ b/jellyfish/_jellyfish.py
@@ -1,3 +1,4 @@
+import warnings
 import unicodedata
 from collections import defaultdict
 from .compat import _range, _zip_longest, IS_PY3
@@ -157,6 +158,16 @@ def jaro_distance(s1, s2):
 
 
 def jaro_winkler(s1, s2, long_tolerance=False):
+
+    warnings.warn(
+        "This function is renamed. Call jaro_winkler_distance from now.",
+        DeprecationWarning, stacklevel=2
+    )
+
+    return _jaro_winkler(s1, s2, long_tolerance, True)
+
+
+def jaro_winkler_distance(s1, s2, long_tolerance=False):
     return _jaro_winkler(s1, s2, long_tolerance, True)
 
 


### PR DESCRIPTION
Fix #72.

Only merge this one if there is a C version available (and close to a new release because the documentation is updated as well)