### PR TITLE
Add property-based tests to ensure C and Python implementations of the same algorithms behave identically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov/
 _build/
 .ipynb_checkpoints/
 .cache
+.hypothesis/

--- a/jellyfish/test_properties.py
+++ b/jellyfish/test_properties.py
@@ -1,0 +1,83 @@
+from hypothesis import given, settings, Verbosity
+from hypothesis.strategies import text
+
+import jellyfish.cjellyfish as cjellyfish
+import jellyfish._jellyfish as pyjellyfish
+
+
+@given(text())
+def test_py_soundex_equals_c_soundex(s):
+    py_soundex = pyjellyfish.soundex(s)
+    c_soundex = cjellyfish.soundex(s)
+    assert py_soundex == c_soundex
+
+
+@given(text())
+def test_py_nysiis_equals_c_nysiis(s):
+    py_nysiis = pyjellyfish.nysiis(s)
+    c_nysiis = cjellyfish.nysiis(s)
+    assert py_nysiis == c_nysiis
+
+
+@given(text())
+def test_py_match_rating_codex_equals_c_match_rating_codex(s):
+    py_match_rating_codex = pyjellyfish.match_rating_codex(s)
+    c_match_rating_codex = cjellyfish.match_rating_codex(s)
+    assert py_match_rating_codex == c_match_rating_codex
+
+
+@given(text())
+def test_py_metaphone_equals_c_metaphone(s):
+    py_metaphone = pyjellyfish.metaphone(s)
+    c_metaphone = cjellyfish.metaphone(s)
+    assert py_metaphone == c_metaphone
+
+
+@given(text())
+def test_py_porter_stem_equals_c_porter_stem(s):
+    py_porter_stem = pyjellyfish.porter_stem(s)
+    c_porter_stem = cjellyfish.porter_stem(s)
+    assert py_porter_stem == c_porter_stem
+
+
+@given(s1=text(), s2=text())
+def test_py_levenshtein_distance_equals_c_levenshtein_distance(s1, s2):
+    py_levenshtein_distance = pyjellyfish.levenshtein_distance(s1, s2)
+    c_levenshtein_distance = cjellyfish.levenshtein_distance(s1, s2)
+    assert py_levenshtein_distance == c_levenshtein_distance
+
+
+@given(s1=text(), s2=text())
+def test_py_damerau_levenshtein_distance_equals_c_damerau_levenshtein_distance(s1, s2):
+    py_damerau_levenshtein_distance = pyjellyfish.damerau_levenshtein_distance(s1, s2)
+    c_damerau_levenshtein_distance = cjellyfish.damerau_levenshtein_distance(s1, s2)
+    assert py_damerau_levenshtein_distance == c_damerau_levenshtein_distance
+
+
+@given(s1=text(), s2=text())
+def test_py_hamming_distance_equals_c_hamming_distance(s1, s2):
+    py_hamming_distance = pyjellyfish.hamming_distance(s1, s2)
+    c_hamming_distance = cjellyfish.hamming_distance(s1, s2)
+    assert py_hamming_distance == c_hamming_distance
+
+
+@given(s1=text(), s2=text())
+def test_py_jaro_distance_equals_c_jaro_distance(s1, s2):
+    py_jaro_distance = pyjellyfish.jaro_distance(s1, s2)
+    c_jaro_distance = cjellyfish.jaro_distance(s1, s2)
+    assert py_jaro_distance == c_jaro_distance
+
+
+@given(s1=text(), s2=text())
+def test_py_jaro_winkler_equals_c_jaro_winkler(s1, s2):
+    py_jaro_winkler = pyjellyfish.jaro_winkler(s1, s2)
+    c_jaro_winkler = cjellyfish.jaro_winkler(s1, s2)
+    assert py_jaro_winkler == c_jaro_winkler
+
+
+@given(s1=text(), s2=text())
+@settings(verbosity=Verbosity.verbose)
+def test_py_match_rating_comparison_equals_c_match_rating_comparison(s1, s2):
+    py_match_rating_comparison = pyjellyfish.match_rating_comparison(s1, s2)
+    c_match_rating_comparison = cjellyfish.match_rating_comparison(s1, s2)
+    assert py_match_rating_comparison == c_match_rating_comparison

--- a/tox.ini
+++ b/tox.ini
@@ -1,47 +1,53 @@
 [tox]
 envlist = py27,pypy,py33,py34,py35,flake8
+deps =
+    pytest
+    unicodecsv
+    hypothesis>=3.6.1,<4.0.0
+
 [testenv:py27]
 whitelist_externals = rm
-commands = 
+commands =
     rm -f jellyfish/cjellyfish.so
     pip install -e .
-    py.test jellyfish/test.py
-deps = pytest
-    unicodecsv
+    pytest jellyfish/test.py jellyfish/test_properties.py
+deps = {[tox]deps}
+
 [testenv:pypy]
-commands = 
+commands =
     pip install -e .
-    py.test jellyfish/test.py
-deps = pytest
-    unicodecsv
+    pytest jellyfish/test.py jellyfish/test_properties.py
+deps = {[tox]deps}
+
 [testenv:py33]
 whitelist_externals = rm
-commands = 
+commands =
     rm -f jellyfish/cjellyfish.so
     pip install -e .
-    py.test jellyfish/test.py
-deps = pytest
-    unicodecsv
+    pytest jellyfish/test.py jellyfish/test_properties.py
+deps = {[tox]deps}
+
 [testenv:py34]
 whitelist_externals = rm
-commands = 
+commands =
     rm -f jellyfish/cjellyfish.so
     pip install -e .
-    py.test jellyfish/test.py
-deps = pytest
-    unicodecsv
+    pytest jellyfish/test.py jellyfish/test_properties.py
+deps = {[tox]deps}
+
 [testenv:py35]
 whitelist_externals = rm
-commands = 
+commands =
     rm -f jellyfish/cjellyfish.so
     pip install -e .
-    py.test jellyfish/test.py
-deps = pytest
-    unicodecsv
+    pytest jellyfish/test.py jellyfish/test_properties.py
+deps = {[tox]deps}
+
 [testenv:flake8]
-basepython=python2.7
+basepython = python2.7
 deps = flake8
 commands = flake8 jellyfish
+
 [flake8]
-max-line-length=99
-ignore=E402,E226
+max-line-length = 99
+ignore = E402,E226


### PR DESCRIPTION
This PR adds a suite of property-based tests that ensure that the C and Python implementations of the same algorithms behave identically. 

The tests show that we have a lot of cleanup work to do, with Hypothesis uncovering failing test cases for all but 3 of Jellyfish's algorithms:

```
$ pytest -v jellyfish/test_properties.py 
====================================================== test session starts =======================================================
platform darwin -- Python 3.5.2, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- python3
cachedir: .cache
rootdir: .../jellyfish, inifile: 
plugins: hypothesis-3.6.1
collected 11 items 

jellyfish/test_properties.py::test_py_soundex_equals_c_soundex FAILED
jellyfish/test_properties.py::test_py_nysiis_equals_c_nysiis FAILED
jellyfish/test_properties.py::test_py_match_rating_codex_equals_c_match_rating_codex FAILED
jellyfish/test_properties.py::test_py_metaphone_equals_c_metaphone FAILED
jellyfish/test_properties.py::test_py_porter_stem_equals_c_porter_stem FAILED
jellyfish/test_properties.py::test_py_levenshtein_distance_equals_c_levenshtein_distance PASSED
jellyfish/test_properties.py::test_py_damerau_levenshtein_distance_equals_c_damerau_levenshtein_distance FAILED
jellyfish/test_properties.py::test_py_hamming_distance_equals_c_hamming_distance PASSED
jellyfish/test_properties.py::test_py_jaro_distance_equals_c_jaro_distance FAILED
jellyfish/test_properties.py::test_py_jaro_winkler_equals_c_jaro_winkler PASSED
jellyfish/test_properties.py::test_py_match_rating_comparison_equals_c_match_rating_comparison Segmentation fault: 11
```

The first problem to be addressed, in my view, is the segmentation fault reported in #73, since that interrupts the test run and prevents Hypothesis from providing a clean report of failing test cases.

Here are some of the failing test cases:

```
$ pytest -s jellyfish/test_properties.py 
====================================================== test session starts =======================================================
platform darwin -- Python 3.5.2, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: .../jellyfish, inifile: 
plugins: hypothesis-3.6.1
collected 11 items 

jellyfish/test_properties.py
Falsifying example: test_py_soundex_equals_c_soundex(s='ı')
Falsifying example: test_py_nysiis_equals_c_nysiis(s='\x80')
Falsifying example: test_py_match_rating_codex_equals_c_match_rating_codex(s='\x80')
Falsifying example: test_py_metaphone_equals_c_metaphone(s='0H')
Falsifying example: test_py_porter_stem_equals_c_porter_stem(s='\x00')
Falsifying example: test_py_damerau_levenshtein_distance_equals_c_damerau_levenshtein_distance(s1='Ā', s2='')
Falsifying example: test_py_jaro_distance_equals_c_jaro_distance(s1='100200', s2='021')
```

This PR updates the Travis CI build to run these tests, so if we merge this PR in that will technically break the build. We can do that, or we can keep this PR open and periodically re-run the build to track our progress as we clean up these bugs, merging it in only when everything has been taken care of.

Fixes #68.
