### PR TITLE
Lists of strings as arguments

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ possible.
 To explicitly use a specific implementation, refer to the appropriate module::
 
   import jellyfish._jellyfish as pyjellyfish
-  import jellyfish.cjellyfish as cjellyfish
+  import jellyfish._cjellyfish as cjellyfish
 
 If you've already imported jellyfish and are not sure what implementation you
 are using, you can check by querying ``jellyfish.library``::

--- a/jellyfish/__init__.py
+++ b/jellyfish/__init__.py
@@ -1,6 +1,7 @@
 try:
-    from .cjellyfish import *   # noqa
+    from ._cjellyfish import *   # noqa
     library = "C"
+
 except ImportError:
     from ._jellyfish import *   # noqa
     library = "Python"

--- a/jellyfish/_cjellyfish.py
+++ b/jellyfish/_cjellyfish.py
@@ -1,0 +1,53 @@
+from . import cjellyfish
+from .cjellyfish import porter_stem   # noqa
+from .utils import phonetic_decorator, compare_decorator
+
+
+@compare_decorator
+def levenshtein_distance(*args, **kwargs):
+    return cjellyfish.levenshtein_distance(*args, **kwargs)
+
+
+@compare_decorator
+def damerau_levenshtein_distance(*args, **kwargs):
+    return cjellyfish.damerau_levenshtein_distance(*args, **kwargs)
+
+
+@compare_decorator
+def jaro_distance(*args, **kwargs):
+    return cjellyfish.jaro_distance(*args, **kwargs)
+
+
+@compare_decorator
+def jaro_winkler(*args, **kwargs):
+    return cjellyfish.jaro_winkler(*args, **kwargs)
+
+
+@compare_decorator
+def hamming_distance(*args, **kwargs):
+    return cjellyfish.hamming_distance(*args, **kwargs)
+
+
+@compare_decorator
+def match_rating_comparison(*args, **kwargs):
+    return cjellyfish.match_rating_comparison(*args, **kwargs)
+
+
+@phonetic_decorator
+def soundex(*args, **kwargs):
+    return cjellyfish.soundex(*args, **kwargs)
+
+
+@phonetic_decorator
+def nysiis(*args, **kwargs):
+    return cjellyfish.nysiis(*args, **kwargs)
+
+
+@phonetic_decorator
+def match_rating_codex(*args, **kwargs):
+    return cjellyfish.match_rating_codex(*args, **kwargs)
+
+
+@phonetic_decorator
+def metaphone(*args, **kwargs):
+    return cjellyfish.metaphone(*args, **kwargs)

--- a/jellyfish/_cjellyfish.py
+++ b/jellyfish/_cjellyfish.py
@@ -5,49 +5,59 @@ from .utils import phonetic_decorator, compare_decorator
 
 @compare_decorator
 def levenshtein_distance(*args, **kwargs):
+    """Compute the Levenshtein distance."""
     return cjellyfish.levenshtein_distance(*args, **kwargs)
 
 
 @compare_decorator
 def damerau_levenshtein_distance(*args, **kwargs):
+    """Compute the Damerau-Levenshtein distance."""
     return cjellyfish.damerau_levenshtein_distance(*args, **kwargs)
 
 
 @compare_decorator
 def jaro_distance(*args, **kwargs):
+    """Compute the Jaro distance."""
     return cjellyfish.jaro_distance(*args, **kwargs)
 
 
 @compare_decorator
 def jaro_winkler(*args, **kwargs):
+    """Compute the Jaro-Winkler distance."""
     return cjellyfish.jaro_winkler(*args, **kwargs)
 
 
 @compare_decorator
 def hamming_distance(*args, **kwargs):
+    """Compute the Hamming distance."""
     return cjellyfish.hamming_distance(*args, **kwargs)
 
 
 @compare_decorator
 def match_rating_comparison(*args, **kwargs):
+    """Compute the Match Rating Approach."""
     return cjellyfish.match_rating_comparison(*args, **kwargs)
 
 
 @phonetic_decorator
 def soundex(*args, **kwargs):
+    """Compute the Soundex code."""
     return cjellyfish.soundex(*args, **kwargs)
 
 
 @phonetic_decorator
 def nysiis(*args, **kwargs):
+    """Compute the NYSIIS code."""
     return cjellyfish.nysiis(*args, **kwargs)
 
 
 @phonetic_decorator
 def match_rating_codex(*args, **kwargs):
+    """Compute the Match Rating Approach code."""
     return cjellyfish.match_rating_codex(*args, **kwargs)
 
 
 @phonetic_decorator
 def metaphone(*args, **kwargs):
+    """"Compute the Metaphone code."""
     return cjellyfish.metaphone(*args, **kwargs)

--- a/jellyfish/_jellyfish.py
+++ b/jellyfish/_jellyfish.py
@@ -10,6 +10,8 @@ from .porter import Stemmer
 
 @compare_decorator
 def levenshtein_distance(s1, s2):
+    """Compute the Levenshtein distance."""
+
     _check_type(s1)
     _check_type(s2)
 
@@ -108,6 +110,8 @@ def _jaro_winkler(ying, yang, long_tolerance, winklerize):
 
 @compare_decorator
 def damerau_levenshtein_distance(s1, s2):
+    """Compute the Damerau-Levenshtein distance."""
+
     _check_type(s1)
     _check_type(s2)
 
@@ -150,16 +154,21 @@ def damerau_levenshtein_distance(s1, s2):
 
 @compare_decorator
 def jaro_distance(s1, s2):
+    """Compute the Jaro distance."""
+
     return _jaro_winkler(s1, s2, False, False)
 
 
 @compare_decorator
 def jaro_winkler(s1, s2, long_tolerance=False):
+    """Compute the Jaro-Winkler distance."""
+
     return _jaro_winkler(s1, s2, long_tolerance, True)
 
 
 @phonetic_decorator
 def soundex(s):
+    """Compute the Soundex code."""
 
     _check_type(s)
 
@@ -205,6 +214,8 @@ def soundex(s):
 
 @compare_decorator
 def hamming_distance(s1, s2):
+    """Compute the Hamming distance."""
+
     _check_type(s1)
     _check_type(s2)
 
@@ -223,6 +234,7 @@ def hamming_distance(s1, s2):
 
 @phonetic_decorator
 def nysiis(s):
+    """Compute the NYSIIS code."""
 
     _check_type(s)
 
@@ -314,6 +326,8 @@ def nysiis(s):
 
 @phonetic_decorator
 def match_rating_codex(s):
+    """Compute the Match Rating Approach code."""
+
     _check_type(s)
 
     s = s.upper()
@@ -338,6 +352,8 @@ def match_rating_codex(s):
 
 @compare_decorator
 def match_rating_comparison(s1, s2):
+    """Compute the Match Rating Approach."""
+
     codex1 = match_rating_codex(s1)
     codex2 = match_rating_codex(s2)
     len1 = len(codex1)
@@ -381,6 +397,8 @@ def match_rating_comparison(s1, s2):
 
 @phonetic_decorator
 def metaphone(s):
+    """"Compute the Metaphone code."""
+
     _check_type(s)
 
     result = []

--- a/jellyfish/_jellyfish.py
+++ b/jellyfish/_jellyfish.py
@@ -1,20 +1,14 @@
-import unicodedata
 from collections import defaultdict
-from .compat import _range, _zip_longest, IS_PY3
+
+from .compat import _range, _zip_longest
+from .utils import (_normalize,
+                    _check_type,
+                    phonetic_decorator,
+                    compare_decorator)
 from .porter import Stemmer
 
 
-def _normalize(s):
-    return unicodedata.normalize('NFKD', s)
-
-
-def _check_type(s):
-    if IS_PY3 and not isinstance(s, str):
-        raise TypeError('expected str or unicode, got %s' % type(s).__name__)
-    elif not IS_PY3 and not isinstance(s, unicode):
-        raise TypeError('expected unicode, got %s' % type(s).__name__)
-
-
+@compare_decorator
 def levenshtein_distance(s1, s2):
     _check_type(s1)
     _check_type(s2)
@@ -112,6 +106,7 @@ def _jaro_winkler(ying, yang, long_tolerance, winklerize):
     return weight
 
 
+@compare_decorator
 def damerau_levenshtein_distance(s1, s2):
     _check_type(s1)
     _check_type(s2)
@@ -153,14 +148,17 @@ def damerau_levenshtein_distance(s1, s2):
     return score[len1+1][len2+1]
 
 
+@compare_decorator
 def jaro_distance(s1, s2):
     return _jaro_winkler(s1, s2, False, False)
 
 
+@compare_decorator
 def jaro_winkler(s1, s2, long_tolerance=False):
     return _jaro_winkler(s1, s2, long_tolerance, True)
 
 
+@phonetic_decorator
 def soundex(s):
 
     _check_type(s)
@@ -205,6 +203,7 @@ def soundex(s):
     return ''.join(result)
 
 
+@compare_decorator
 def hamming_distance(s1, s2):
     _check_type(s1)
     _check_type(s2)
@@ -222,6 +221,7 @@ def hamming_distance(s1, s2):
     return distance
 
 
+@phonetic_decorator
 def nysiis(s):
 
     _check_type(s)
@@ -312,6 +312,7 @@ def nysiis(s):
     return key
 
 
+@phonetic_decorator
 def match_rating_codex(s):
     _check_type(s)
 
@@ -335,6 +336,7 @@ def match_rating_codex(s):
         return ''.join(codex)
 
 
+@compare_decorator
 def match_rating_comparison(s1, s2):
     codex1 = match_rating_codex(s1)
     codex2 = match_rating_codex(s2)
@@ -377,6 +379,7 @@ def match_rating_comparison(s1, s2):
     return (6 - max(unmatched_count1, unmatched_count2)) >= min_rating
 
 
+@phonetic_decorator
 def metaphone(s):
     _check_type(s)
 

--- a/jellyfish/test.py
+++ b/jellyfish/test.py
@@ -25,7 +25,7 @@ def jf(request):
     if request.param == 'python':
         from jellyfish import _jellyfish as jf
     else:
-        from jellyfish import cjellyfish as jf
+        from jellyfish import _cjellyfish as jf
     return jf
 
 
@@ -106,7 +106,7 @@ def test_porter_stem(jf):
 if platform.python_implementation() == 'CPython':
     def test_match_rating_comparison_segfault():
         import hashlib
-        from jellyfish import cjellyfish as jf
+        from jellyfish import _cjellyfish as jf
         sha1s = [u'{}'.format(hashlib.sha1(str(v).encode('ascii')).hexdigest())
                  for v in range(100)]
         # this segfaulted on 0.1.2
@@ -114,7 +114,7 @@ if platform.python_implementation() == 'CPython':
 
     def test_damerau_levenshtein_unicode_segfault():
         # unfortunate difference in behavior between Py & C versions
-        from jellyfish.cjellyfish import damerau_levenshtein_distance as c_dl
+        from jellyfish._cjellyfish import damerau_levenshtein_distance as c_dl
         from jellyfish._jellyfish import damerau_levenshtein_distance as py_dl
         s1 = u'mylifeoutdoors'
         s2 = u'нахлыст'

--- a/jellyfish/utils.py
+++ b/jellyfish/utils.py
@@ -1,0 +1,47 @@
+import unicodedata
+from functools import wraps
+
+from .compat import IS_PY3
+
+
+def _normalize(s):
+    return unicodedata.normalize('NFKD', s)
+
+
+def _check_type(s):
+    if IS_PY3 and not isinstance(s, str):
+        raise TypeError('expected str or unicode, got %s' % type(s).__name__)
+    elif not IS_PY3 and not isinstance(s, unicode):
+        raise TypeError('expected unicode, got %s' % type(s).__name__)
+
+
+def compare_decorator(func):
+
+    @wraps(func)
+    def wrapper(s1, s2, *args, **kwargs):
+
+        if isinstance(s1, (list)) and isinstance(s1, (list)):
+            if len(s1) != len(s2):
+                raise ValueError("length of list s1 has to be equal to the"
+                                 "length of list s2")
+
+            return [func(s1i, s2j, *args, **kwargs) for s1i, s2j in zip(s1, s2)]
+        else:
+            return func(s1, s2, *args, **kwargs)
+    return wrapper
+
+
+def phonetic_decorator(func):
+
+    @wraps(func)
+    def wrapper(s, *args, **kwargs):
+
+        if isinstance(s, (list)):
+
+            return [func(si, *args, **kwargs) for si in s]
+
+        else:
+            return func(s, *args, **kwargs)
+    return wrapper
+
+

--- a/jellyfish/utils.py
+++ b/jellyfish/utils.py
@@ -43,5 +43,3 @@ def phonetic_decorator(func):
         else:
             return func(s, *args, **kwargs)
     return wrapper
-
-


### PR DESCRIPTION
This pull request adds a new feature. Hope you like it. Lists of strings are now accepted as arguments for the distance and phonetic algorithms. This is also possible for the C implementation. 

Aim: 
- Make it possible to compute large sets efficiently (in parallel). 
- Easier to add features. 

## Example

Python version 

``` python 
>>> from jellyfish import _jellyfish as pyjf

>>> pyjf.soundex(['jelly', 'jellyfish'])
['J400', 'J412']
>>> pyjf.soundex('jelly')
'J400'

>>> pyjf.jaro_winkler(['jelly', 'jellyfish'], ['jelly', 'jellyfihs'])
[1.0, 0.9777777777777777]
>>> pyjf.jaro_winkler('jellyfish', 'jellyfihs')
0.9777777777777777
```

C version

``` python
>>> from jellyfish import _cjellyfish as cjf

>>> cjf.soundex(['jelly', 'jellyfish'])
['J400', 'J412']
>>> cjf.soundex('jelly')
'J400'

>>> cjf.jaro_winkler(['jelly', 'jellyfish'], ['jelly', 'jellyfihs'])
[1.0, 0.9777777777777777]
>>> cjf.jaro_winkler('jellyfish', 'jellyfihs')
0.9777777777777777
```

## API

The API is a bit changed. `import jellyfish` imports one of those: 
```
from jellyfish import _cjellyfish
from jellyfish import _jellyfish
```
In fact, `from jellyfish import _cjellyfish` is no longer completely pure C. 

It is possible to import the pure C version with `from jellyfish import cjellyfish`. List are not accepted then. 
