### PR TITLE
BUG: In Which We Match the C Version's Behavior for Ws Followed By Vowels in Metaphones

### DIFF
--- a/jellyfish/_jellyfish.py
+++ b/jellyfish/_jellyfish.py
@@ -466,7 +466,9 @@ def metaphone(s):
         elif c == 'w':
             if i == 0 and next == 'h':
                 i += 1
-            if nextnext in 'aeiou' or nextnext == '*****':
+                if nextnext in 'aeiou' or nextnext == '*****':
+                    result.append('w')
+            elif next in 'aeiou' or next == '*****':
                 result.append('w')
         elif c == 'x':
             if i == 0:


### PR DESCRIPTION
There's a discrepancy between the C and Python jellyfish implementations for metaphone with what it does for W's followed by vowels. `metaphone('Walt')` is 'WLT' in the C and 'LT' in the Python versions. It looks like 'WLT' should be the correct behavior.

I guess it is a good thing both that my name is Walt and that I've been forced to use the pure Python rather than C version of this function in two different places!

C version: https://github.com/jamesturk/cjellyfish/blob/7dd0c08aec07833958a6f3d115af88c585e3ba0b/metaphone.c#L160

Test case provided in https://github.com/jamesturk/jellyfish-testdata/pull/4