### PR TITLE
damerau_levenshtein_distance: add support for non-ASCII characters

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/jamesturk/jellyfish-testdata.git
 [submodule "cjellyfish"]
 	path = cjellyfish
-	url = https://github.com/jamesturk/cjellyfish.git
+	url = https://github.com/immerrr/cjellyfish.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
   - "3.5"
   - "3.6"
   - "pypy3"
-install: pip install -e .
+install:
+  - python setup.py build_ext --inplace
+  - pip install -e .
 script: py.test jellyfish/test.py
 after_success:
     - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ install:
     - "git submodule update --init --recursive"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "python --version"
+    - "%CMD_IN_ENV% python setup.py build_ext --inplace"
     - "%CMD_IN_ENV% pip install -e ."
     - "%CMD_IN_ENV% pip install pytest wheel"
 

--- a/jellyfish/test.py
+++ b/jellyfish/test.py
@@ -108,16 +108,13 @@ if platform.python_implementation() == 'CPython':
         # this segfaulted on 0.1.2
         assert [[jf.match_rating_comparison(h1, h2) for h1 in sha1s] for h2 in sha1s]
 
-    def test_damerau_levenshtein_unicode_segfault():
-        # unfortunate difference in behavior between Py & C versions
+    def test_damerau_levenshtein_unicode():
         from jellyfish.cjellyfish import damerau_levenshtein_distance as c_dl
         from jellyfish._jellyfish import damerau_levenshtein_distance as py_dl
         s1 = u'mylifeoutdoors'
         s2 = u'нахлыст'
-        with pytest.raises(ValueError):
-            c_dl(s1, s2)
-        with pytest.raises(ValueError):
-            c_dl(s2, s1)
+        assert c_dl(s1, s2) == 14
+        assert c_dl(s2, s1) == 14
 
         assert py_dl(s1, s2) == 14
         assert py_dl(s2, s1) == 14


### PR DESCRIPTION
This PR should enable support for non-ASCII characters for `damerau_levenshtein_distance`.

The initial commit points the cjellyfish submodule to my repo, because the branch is not yet accepted in the cjellyfish repository (https://github.com/jamesturk/cjellyfish/pull/5), to ensure CI tests are run against it.