### PR TITLE
docs: fix simple typo, consonent -> consonant

### DIFF
--- a/jellyfish/porter.py
+++ b/jellyfish/porter.py
@@ -123,7 +123,7 @@ class Stemmer(object):
         return self.cons(j)
 
     def cvc(self, i):
-        """ True iff i-2,i-1,i is consonent-vowel consonant
+        """ True iff i-2,i-1,i is consonant-vowel consonant
         and if second c isn't w,x, or y.
         used to restore e at end of short words like cave, love, hope, crime
         """


### PR DESCRIPTION
There is a small typo in jellyfish/porter.py.

Should read `consonant` rather than `consonent`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md