### PR TITLE
Update CI for easy releasing of binary wheels to PyPI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -48,8 +48,11 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', pypy3]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          python-version: pypy3
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,10 +6,10 @@ on:
     - v*
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   test:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,32 +1,97 @@
 name: Python package
 
-on: [push]
+on:
+  create:
+    tags:
+    - v*
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
-  build:
-
+  test:
+    name: "Test ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ['3.6', '3.7', '3.8', '3.9', pypy3]
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Checkout submodules
       run: |
         git submodule init
         git submodule update
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .
+
     - name: Test with pytest
       run: |
         pip install pytest
         pytest jellyfish/test.py
+
+  build:
+    name: "Build ${{ matrix.python-version }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', pypy3]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout submodules
+      run: |
+        git submodule init
+        git submodule update
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip build
+
+    - name: Build package
+      run: python -m build
+
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: artifacts
+        path: dist/*
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs:
+    - build
+
+    # Only publish tags
+    if: github.event_name == 'create' && github.event.ref_type == 'tag'
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifacts
+        path: dist
+
+    - name: Push build artifacts to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        skip_existing: true
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
cc @jamesturk Hello there! I was about to use this and noticed that there were no pre-compiled wheels for Windows nor macOS so I added that to the CI. On tags starting with `v` it'll upload to PyPI if you follow https://pypi.org/help/#apitoken and add the secret to the repo settings (PRs from forks won't see secrets)

Also, every build job will produce wheels that can be downloaded