### PR TITLE
Re-name Linux AArch64 artifacts

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -157,7 +157,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: dist
+        name: artifacts
         path: wheelhouse/*
 
   publish:


### PR DESCRIPTION
Uploading the AArch64 wheels with the name `artifacts` instead of `dist` as it is uploading the wheels on PyPi from artifacts and not dist.
