### PR TITLE
LGTM.com configuration

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,8 @@
+# This file contains configuration for the LGTM tool: https://lgtm.com/
+# The jellyfish repository is continuously scanned by the LGTM tool for
+# any security and/or code vulnerabilities. You can find the alert here:
+# https://lgtm.com/projects/g/jamesturk/jellyfish/
+extraction:
+  python:
+    python_setup:
+      version: 3


### PR DESCRIPTION
This is an attempt to get LGTM.com to use Python 3 instead of Python 2, to have all the false positives disappear from this page:
	https://lgtm.com/projects/g/jamesturk/jellyfish/alerts/

See also https://github.com/github/codeql/issues/7214.