### PR TITLE
remove python2.6 compatibility code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,19 +7,6 @@ from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatfo
 
 # large portions ripped off from simplejson's setup.py
 
-if sys.platform == "win32" and sys.version_info > (2, 6):
-    # 2.6's distutils.msvc9compiler can raise an IOError when failing to find the compiler
-    # It can also raise ValueError http://bugs.python.org/issue7511
-    ext_errors = (
-        CCompilerError,
-        DistutilsExecError,
-        DistutilsPlatformError,
-        IOError,
-        ValueError,
-    )
-else:
-    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
-
 IS_PYPY = hasattr(sys, "pypy_translation_info")
 
 
@@ -37,7 +24,7 @@ class ve_build_ext(build_ext):
     def build_extension(self, ext):
         try:
             build_ext.build_extension(self, ext)
-        except ext_errors:
+        except (CCompilerError, DistutilsExecError, DistutilsPlatformError):
             raise BuildFailed()
 
 


### PR DESCRIPTION
I addition this condition was actually always incorrect, since it should have used:
```python
if sys.platform == "win32" and sys.version_info < (2, 7):
```
instead of
```python
if sys.platform == "win32" and sys.version_info > (2, 6):
```
which was fixed in simplejson in https://github.com/simplejson/simplejson/commit/687d0e80f377c252451a4067acbcdc2e1db88a00