### PR TITLE
fixed python 3.11 on musllinux 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,7 +95,6 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: v1.0.0-beta.7
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i ${{ matrix.platform.interpreter }}
           sccache: 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,10 +78,10 @@ jobs:
         platform:
           - target: x86_64-unknown-linux-musl
             arch: x86_64
-            interpreter: 3.7 3.8 3.9 3.10 pypy3.8 pypy3.9
+            interpreter: 3.7 3.8 3.9 3.10 3.11 pypy3.8 pypy3.9
           - target: i686-unknown-linux-musl
             arch: x86
-            interpreter: 3.7 3.8 3.9 3.10 pypy3.8 pypy3.9
+            interpreter: 3.7 3.8 3.9 3.10 3.11 pypy3.8 pypy3.9
         # all values: [x86_64, x86, aarch64, armhf, armv7, ppc64le, riscv64, s390x]
         # { target: "aarch64-unknown-linux-musl", arch: "aarch64" },
         # { target: "armv7-unknown-linux-musleabihf", image_tag: "armv7" },

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,10 +78,10 @@ jobs:
         platform:
           - target: x86_64-unknown-linux-musl
             arch: x86_64
-            interpreter: 3.7 3.8 3.9 3.10 3.11 pypy3.8 pypy3.9
+            interpreter: 3.7 3.8 3.9 3.10 pypy3.8 pypy3.9
           - target: i686-unknown-linux-musl
             arch: x86
-            interpreter: 3.7 3.8 3.9 3.10 3.11 pypy3.8 pypy3.9
+            interpreter: 3.7 3.8 3.9 3.10 pypy3.8 pypy3.9
         # all values: [x86_64, x86, aarch64, armhf, armv7, ppc64le, riscv64, s390x]
         # { target: "aarch64-unknown-linux-musl", arch: "aarch64" },
         # { target: "armv7-unknown-linux-musleabihf", image_tag: "armv7" },

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: v1.0.0-beta.7
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i ${{ matrix.platform.interpreter }}
           sccache: 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ license = "MIT"
 readme = "README.md"
 
 
-[package.metadata.maturin]
-name = "jellyfish._rustyfish"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "jellyfish"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,4 @@ repository = "https://github.com/jamesturk/jellyfish/"
 [tool.maturin]
 features = ["pyo3/extension-module", "python"]
 python-source = "python"
+module-name = "jellyfish._rustyfish"


### PR DESCRIPTION
Hi,
After doing some tests, I discovered that the wheel available for musllinux python 3.11 does not work due to an issue with pyo3/maturin. On lower python versions or on normal linux instead it works.

https://github.com/PyO3/maturin/issues/1559

This generates the following error:
```
import jellyfish
  File "/app/.venv/lib/python3.11/site-packages/jellyfish/__init__.py", line 3, in <module>
    from ._rustyfish import *
ModuleNotFoundError: No module named 'jellyfish._rustyfish'
```

To reproduce on the latest jellyfish I am following this script:

```bash
# set up quemu for architecture emulation
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

# x64
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.11-slim sh /app/script.sh 
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.10-slim sh /app/script.sh 
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.9-slim sh /app/script.sh 
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.8-slim sh /app/script.sh 
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.7-slim sh /app/script.sh 

# x86
docker run --rm -it --platform=linux/aarch64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.11-slim sh /app/script.sh 
docker run --rm -it --platform=linux/aarch64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.10-slim sh /app/script.sh 
docker run --rm -it --platform=linux/aarch64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.9-slim sh /app/script.sh 
docker run --rm -it --platform=linux/aarch64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.8-slim sh /app/script.sh 
docker run --rm -it --platform=linux/aarch64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.7-slim sh /app/script.sh  


# musllinux

# 3.11: ImportError: cannot import name '_rustyfish' in import jellyfish
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.11-alpine sh /app/script.sh 
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.10-alpine sh /app/script.sh 
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.9-alpine sh /app/script.sh 
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.8-alpine sh /app/script.sh 
docker run --rm -it --platform=linux/x86_64 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.7-alpine sh /app/script.sh 

# x86
# 3.11: ImportError: cannot import name '_rustyfish' in import jellyfish
docker run --rm -it --platform=linux/386 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.11-alpine sh /app/script.sh 
docker run --rm -it --platform=linux/386 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.10-alpine sh /app/script.sh 
docker run --rm -it --platform=linux/386 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.9-alpine sh /app/script.sh 
docker run --rm -it --platform=linux/386 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.8-alpine sh /app/script.sh 
docker run --rm -it --platform=linux/386 -v `pwd`/script.sh:/app/script.sh -v `pwd`/tests:/app/tests -v `pwd`/testdata:/app/testdata python:3.7-alpine sh /app/script.sh 
```

We should find a way to test the generated wheels in github actions with docker, to be sure to generate working wheels.

Best,
Martino

