### PR TITLE
Bumped version of pyo3 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jellyfish"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 description = "Approximate and phonetic matching of strings."
 authors = ["James Turk <dev@jamesturk.net>"]
@@ -15,7 +15,7 @@ name = "jellyfish"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.18.0"
+pyo3 = "0.20.0"
 unicode-segmentation = "^1.6.0"
 unicode-normalization = "^0.1"
 smallvec = "1.10.0"


### PR DESCRIPTION
Bumped the minor version of the pyo3 dependency from `0.18.0` to `0.20.0`.
Also bumped patch version of this project from `1.0.2` to `1.0.3`.