### PR TITLE
putative fix for windows releases (however, I am unable to test)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,12 +124,12 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.platform.interpreter }}
+          python-version: ${{ matrix.interpreter }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist -i ${{ matrix.platform.interpreter }}
+          target: ${{ matrix.target }}
+          args: --release --out dist -i ${{ matrix.interpreter }}
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
It seems there was a problem with the changes I made to CI.yml to get it to work with Python 3.13. Somehow, it broke the upload of windows wheels. Because my test setup did not & cannot try uploading to pypi.org, I wasn't able to see the problem myself - it only became clear when you released 1.12 yourself.

I believe that this PR will fix the problem, but I am unable to test it myself, for the same reason.