### PR TITLE
pyproject.toml: Allow maturin >= 1.8.0 to fill the version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "jellyfish"
+dynamic = ["version"]
 requires-python = ">=3.8"
 classifiers = [
   "Programming Language :: Rust",


### PR DESCRIPTION
maturin >= 1.8.0 stopped filling the version from Cargo.toml, because the spec only allows this, when the metadata key is listed in `dynamic` [1][2].

Fixes #224.

[1] https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic
[2] https://github.com/PyO3/maturin/issues/2390